### PR TITLE
webView now has a uiDelegate

### DIFF
--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -52,6 +52,12 @@ public class TurboNavigator {
             }
         }
     }
+    
+    /// Only works if Session is extending the WKUIDelegate.  Gives the webview that sessions hold a uiDelegate which allows for javascript
+    /// events to be shown in a web view.   Ex. javascript Alert() 
+    public func setUIDelegateForJavascriptActionsOnSession(){
+        self.session.webView.uiDelegate = self.session as? WKUIDelegate
+    }
 
     // MARK: Internal
 


### PR DESCRIPTION
Since the session is not exposed we can use this method to set the uiDelegate which is used so the web view may listen into javascript Alert events and allow our app to react to those.